### PR TITLE
fix(old-icon-font): Remove old icon font since it is not used

### DIFF
--- a/assets/styles/globals/icons/_icons.scss
+++ b/assets/styles/globals/icons/_icons.scss
@@ -11,34 +11,16 @@
  *
  */
 
-
 /***************************
     INLOCOMEDIA ICON FONT
 ****************************/
-
-// Basics Paths
-
-$icon-font-path:          "~/assets/fonts";
-$icon-font-name:          "supernova";
-$icon-font-svg-id:        "supernova";
-
-@font-face {
-  font-family: 'Supernova';
-  src:url('#{$icon-font-path}#{$icon-font-name}.eot');
-  src:url('#{$icon-font-path}#{$icon-font-name}.eot?#iefix') format('embedded-opentype'),
-      url('#{$icon-font-path}#{$icon-font-name}.svg##{$icon-font-name}') format('svg'),
-      url('#{$icon-font-path}#{$icon-font-name}.woff') format('woff'),
-      url('#{$icon-font-path}#{$icon-font-name}.ttf') format('truetype');
-  font-weight: normal;
-  font-style: normal;
-}
 
 // Catchall baseclass
 
 .sn-icon {
   position: relative;
   display: inline-block;
-  font-family: 'Supernova';
+  font-family: "Supernova";
   font-style: normal;
   font-weight: normal;
   line-height: 1;
@@ -49,11 +31,16 @@ $icon-font-svg-id:        "supernova";
   font-size: 24px;
 }
 
-
 // INDIVIDUAL ICONS
 
-
 //  System
-.sn-icon__supernova--brand                           { &:before {content: "\e900";} }
-.sn-icon__inlocomedia--brand                         { &:before {content: "\e901";} }
-
+.sn-icon__supernova--brand {
+  &:before {
+    content: "\e900";
+  }
+}
+.sn-icon__inlocomedia--brand {
+  &:before {
+    content: "\e901";
+  }
+}

--- a/assets/styles/globals/icons/_supernova_logo.scss
+++ b/assets/styles/globals/icons/_supernova_logo.scss
@@ -11,36 +11,16 @@
  *
  */
 
-
 /***************************
     INLOCOMEDIA ICON FONT
 ****************************/
 
-
-// Basics Paths
-
-$icon-font-path:          "~/assets/fonts";
-$icon-font-name:          "supernova";
-$icon-font-svg-id:        "supernova";
-
-@font-face {
-  font-family: 'Supernova';
-  src:url('#{$icon-font-path}#{$icon-font-name}.eot');
-  src:url('#{$icon-font-path}#{$icon-font-name}.eot?#iefix') format('embedded-opentype'),
-      url('#{$icon-font-path}#{$icon-font-name}.svg##{$icon-font-name}') format('svg'),
-      url('#{$icon-font-path}#{$icon-font-name}.woff') format('woff'),
-      url('#{$icon-font-path}#{$icon-font-name}.ttf') format('truetype');
-  font-weight: normal;
-  font-style: normal;
-}
-
 // Catchall baseclass
-
 
 .sn-icon {
   position: relative;
   display: inline-block;
-  font-family: 'Supernova';
+  font-family: "Supernova";
   font-style: normal;
   font-weight: normal;
   line-height: 1;
@@ -51,12 +31,16 @@ $icon-font-svg-id:        "supernova";
   font-size: 24px;
 }
 
-
 // INDIVIDUAL ICONS
 
-
 //  System
-.sn-icon__supernova--brand                           { &:before {content: "\e900";} }
-.sn-icon__inlocomedia--brand                         { &:before {content: "\e901";} }
-
-
+.sn-icon__supernova--brand {
+  &:before {
+    content: "\e900";
+  }
+}
+.sn-icon__inlocomedia--brand {
+  &:before {
+    content: "\e901";
+  }
+}


### PR DESCRIPTION
No CRA novo (3+), quebra o build porque há uma referência fora do `src`:

``` 
./src/assets/styles/app.scss (./node_modules/css-loader/dist/cjs.js??ref--6-oneOf-5-1!./node_modules/postcss-loader/src??postcss!./node_modules/sass-loader/lib/loader.js??ref--6-oneOf-5-3!./src/assets/styles/app.scss)
Module not found: You attempted to import ../../../../../../../assets/fontssupernova.eot which falls outside of the project src/ directory. Relative imports outside of src/ are not supported.
```